### PR TITLE
ci(merge-pr): Node 20 LTS and pinned Octokit deps in scripts; use npm ci/install in scripts dir

### DIFF
--- a/.github/workflows/merge-pr.yml
+++ b/.github/workflows/merge-pr.yml
@@ -11,7 +11,7 @@ on:
 permissions:
   contents: read
   pull-requests: read
-  checks: write
+  checks: read
 
 jobs:
   run-safe-merge-checks:
@@ -31,39 +31,24 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
 
-      - name: Debug workspace
+      - name: Install deps (prefer lockfile)
+        working-directory: scripts
         run: |
-          echo "GITHUB_WORKSPACE: $GITHUB_WORKSPACE"
-          echo "Repository: $GITHUB_REPOSITORY"
-          pwd
-          echo "Top-level files:"
-          ls -la || true
-          echo "Listing repository contents (up to 3 levels):"
-          find . -maxdepth 3 -print || true
-
-      - name: Install dependencies
-        run: |
-          # Prefer npm ci if a lockfile is present for reproducible installs
           if [ -f package-lock.json ] || [ -f npm-shrinkwrap.json ]; then
             echo "Lockfile detected, running npm ci"
             npm ci
           else
-            echo "No lockfile detected"
-            if [ ! -f package.json ]; then
-              echo "Initializing package.json"
-              npm init -y
-            fi
-            echo "Installing required dependencies"
-            npm install @octokit/app @octokit/rest
+            echo "No lockfile detected in scripts/, installing pinned deps from package.json"
+            npm install --no-audit --no-fund
           fi
 
       - name: Run safe merge checks
+        working-directory: scripts
         env:
           APP_ID: ${{ secrets.APP_ID }}
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           PULL_NUMBER: ${{ github.event.inputs.pull_number }}
-        run: |
-          node scripts/merge-pr-checks.js
+        run: node merge-pr-checks.js

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "smartmailsorter-ci",
+  "private": true,
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@octokit/auth-app": "7.0.1",
+    "@octokit/rest": "21.0.0"
+  }
+}


### PR DESCRIPTION
Summary
- Update .github/workflows/merge-pr.yml to use Node.js 20 LTS.
- Install dependencies from scripts/ using a pinned package.json (npm ci if lockfile is present, otherwise npm install). This avoids ad-hoc, unpinned installs in the repository root.
- Keep the workflow manual-only (workflow_dispatch with pull_number input). No automatic PR triggers added.
- No Checks API verification added; the script behavior remains the same (optional legacy statuses wait only if requiredContexts is configured in the script).

Changes
- Added scripts/package.json with pinned versions:
  - @octokit/auth-app: 7.0.1
  - @octokit/rest: 21.0.0
- Updated merge-pr.yml:
  - Node 18 -> 20
  - Install deps from scripts/ with npm ci or npm install
  - Use working-directory: scripts when running merge-pr-checks.js
  - Minimal GITHUB_TOKEN permissions (contents/pull-requests/checks: read) since the job relies on the GitHub App token for privileged operations

What’s not included (per request)
- No automatic run on PR events
- No additional verification of modern check runs via the Checks API

Why
- Node 18 is EOL; Node 20 is current LTS.
- Pinned dependencies improve supply-chain security and reproducibility.
- Installing in scripts/ keeps the repo root clean and makes dependency intent explicit.

Validation
- The workflow should continue to function exactly as before (manual trigger with pull_number input), but with deterministic dependency installation and Node 20 runtime.

Next steps (optional)
- Commit a package-lock.json under scripts/ to enable npm ci consistently.
- If desired, I can follow up with a PR to add a minimal app-commit workflow for direct commits using the App token, and optionally enhance merge-pr-checks.js to verify GitHub Actions check runs.
