### PR TITLE
ci(app-commit): add workflow to push commits to main using GitHub App installation token

### DIFF
--- a/.github/workflows/app-commit.yml
+++ b/.github/workflows/app-commit.yml
@@ -1,0 +1,79 @@
+name: app-commit
+
+on:
+  workflow_dispatch:
+    inputs:
+      file:
+        description: "Relative path to file to update"
+        required: false
+        default: ".github/healthcheck"
+      content:
+        description: "Line to append"
+        required: false
+        default: "updated by app at $GITHUB_RUN_ID"
+
+permissions:
+  contents: read  # job uses the App installation token for push
+
+jobs:
+  commit:
+    name: Commit to main using GitHub App
+    runs-on: ubuntu-latest
+    env:
+      APP_ID: ${{ secrets.APP_ID }}
+      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+      REPO: ${{ github.repository }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Get installation token
+        id: token
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > get-token.mjs <<'EOF'
+          import { Octokit } from "@octokit/rest";
+          import { createAppAuth } from "@octokit/auth-app";
+          const [owner, repo] = process.env.REPO.split("/");
+          const appOctokit = new Octokit({
+            authStrategy: createAppAuth,
+            auth: {
+              appId: Number(process.env.APP_ID),
+              privateKey: process.env.PRIVATE_KEY.replace(/\\n/g, "\n"),
+            },
+          });
+          const inst = await appOctokit.request("GET /repos/{owner}/{repo}/installation", { owner, repo });
+          const { token } = await appOctokit.auth({ type: "installation", installationId: inst.data.id });
+          console.log(`::add-mask::${token}`);
+          console.log(`token=${token}`);
+          EOF
+          npm init -y >/dev/null 2>&1
+          npm i @octokit/rest @octokit/auth-app >/dev/null 2>&1
+          node get-token.mjs >> "$GITHUB_OUTPUT"
+
+      - name: Configure git as App bot
+        run: |
+          git config user.name "github-app[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${{ steps.token.outputs.token }}@github.com/${{ github.repository }}.git
+
+      - name: Make a change and push to main
+        shell: bash
+        run: |
+          set -euo pipefail
+          file_path="${{ github.event.inputs.file }}"
+          line="${{ github.event.inputs.content }}"
+          mkdir -p "$(dirname "$file_path")"
+          echo "$line" >> "$file_path"
+          git add "$file_path"
+          git commit -m "chore(app): automated update via GitHub App"
+          # Push directly to main (requires App to be allowed to bypass PR requirements in branch protection)
+          git push origin HEAD:main


### PR DESCRIPTION
This PR adds a new workflow to support Pattern B (GitHub App-driven commits) as discussed.

What’s included:
- .github/workflows/app-commit.yml
  - Manual trigger (workflow_dispatch) with two inputs:
    - file (default: .github/healthcheck)
    - content (default: "updated by app at $GITHUB_RUN_ID")
  - Uses the repository GitHub App credentials (APP_ID, PRIVATE_KEY) to obtain an installation token via @octokit/auth-app
  - Configures git to authenticate via x-access-token and pushes directly to main
  - Requires that the GitHub App is granted Contents: Read/Write and is allowed to bypass PR requirements for main in branch protection settings
  - Uses Node 20 LTS

How to test:
1) Ensure the GitHub App is installed on this repo and has permissions: Contents (Read/Write). Optionally Checks/PRs permissions if you also use it for merges.
2) In Settings → Branches → main rule, under “Bypass pull request requirements,” add this GitHub App so it can push to main.
3) Go to Actions → app-commit → Run workflow, keep defaults. The workflow will append a line to .github/healthcheck and push to main.

Security & notes:
- The job uses only the App’s installation token; GITHUB_TOKEN is not used for privileged operations.
- No automatic triggers to avoid unintended writes to main; manual-only dispatch as requested.
- We can later add a scripts/package.json + lockfile to pin Node deps used during token generation, or refactor to reuse the repo’s scripts deps.

If you’d like, I can follow up with a PR that reuses the scripts toolchain (npm ci from scripts/) for token generation, or adds an environment protection to restrict who can dispatch this workflow.