### PR TITLE
chore(style): enforce consistent whitespace and line endings; fix ThisAddIn.cs formatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+root = true
+
+[*.cs]
+charset = utf-8-bom
+end_of_line = crlf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+
+[*.{csproj,sln}]
+end_of_line = crlf
+insert_final_newline = true
+
+[*.{json,xml,yml,yaml,md}]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,15 @@
+# Ensure Windows-style line endings for C# and solution/project files
+*.cs text eol=crlf
+*.csproj text eol=crlf
+*.sln text eol=crlf
+
+# Normalize text files; keep default LF for common config formats
+*.json text eol=lf
+*.xml  text eol=lf
+*.yml  text eol=lf
+*.yaml text eol=lf
+*.md   text eol=lf
+
+# Treat these as text for diffing
+*.resx text
+*.config text

--- a/ThisAddIn.cs
+++ b/ThisAddIn.cs
@@ -27,7 +27,7 @@ namespace OutlookMailSorter
 
         private void ThisAddIn_Shutdown(object sender, EventArgs e)
         {
-            // Note: Outlook no longer raises this event. If you have code that 
+            // Note: Outlook no longer raises this event. If you have code that
             //    must run when Outlook shuts down, see https://go.microsoft.com/fwlink/?LinkId=506785
         }
 
@@ -65,7 +65,7 @@ namespace OutlookMailSorter
             this.Startup += new System.EventHandler(ThisAddIn_Startup);
             this.Shutdown += new System.EventHandler(ThisAddIn_Shutdown);
         }
-        
+
         #endregion
     }
 }


### PR DESCRIPTION
This PR addresses the ci-style failures and prevents future whitespace/line-ending drift.

Changes
- Add .editorconfig to enforce:
  - CRLF for C# and solution/project files
  - 4-space indentation, trim trailing whitespace
  - Final newline
  - LF for common config formats (json/xml/yaml/md)
- Add .gitattributes to normalize line endings across platforms:
  - Force CRLF for *.cs, *.csproj, *.sln
  - Use LF for json/xml/yaml/md
  - Mark resx/config as text
- Normalize whitespace in ThisAddIn.cs:
  - Remove stray spaces on blank line(s)
  - Ensure indentation is spaces (4 per level)
  - Ensure a single blank line before #region end and proper final newline

Why
- The ci-style job (dotnet format whitespace) failed with errors on ThisAddIn.cs line 68/70 due to incorrect whitespace. These changes correct that and establish repo-wide enforcement so CI and local environments are consistent.

Notes
- After merging, developers may need to re-checkout to apply .gitattributes normalization. To force normalization locally, run:
  - `git rm --cached -r .`
  - `git reset --hard`
- No functional code changes.
