### PR TITLE
ci(app-commit): switch to tibdex/github-app-token for installation token and simplify workflow

### DIFF
--- a/.github/workflows/app-commit.yml
+++ b/.github/workflows/app-commit.yml
@@ -19,51 +19,25 @@ jobs:
   commit:
     name: Commit to main using GitHub App
     runs-on: ubuntu-latest
-    env:
-      APP_ID: ${{ secrets.APP_ID }}
-      PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
-      REPO: ${{ github.repository }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - name: Generate installation token
+        id: app-token
+        uses: tibdex/github-app-token@v2
         with:
-          node-version: 20
-
-      - name: Get installation token
-        id: token
-        shell: bash
-        run: |
-          set -euo pipefail
-          cat > get-token.mjs <<'EOF'
-          import { Octokit } from "@octokit/rest";
-          import { createAppAuth } from "@octokit/auth-app";
-          const [owner, repo] = process.env.REPO.split("/");
-          const appOctokit = new Octokit({
-            authStrategy: createAppAuth,
-            auth: {
-              appId: Number(process.env.APP_ID),
-              privateKey: process.env.PRIVATE_KEY.replace(/\\n/g, "\n"),
-            },
-          });
-          const inst = await appOctokit.request("GET /repos/{owner}/{repo}/installation", { owner, repo });
-          const { token } = await appOctokit.auth({ type: "installation", installationId: inst.data.id });
-          console.log(`::add-mask::${token}`);
-          console.log(`token=${token}`);
-          EOF
-          npm init -y >/dev/null 2>&1
-          npm i @octokit/rest @octokit/auth-app >/dev/null 2>&1
-          node get-token.mjs >> "$GITHUB_OUTPUT"
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
 
       - name: Configure git as App bot
         run: |
           git config user.name "github-app[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git remote set-url origin https://x-access-token:${{ steps.token.outputs.token }}@github.com/${{ github.repository }}.git
+          git remote set-url origin https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git
 
       - name: Make a change and push to main
         shell: bash


### PR DESCRIPTION
This PR updates the app-commit workflow to use tibdex/github-app-token (Option A) for obtaining a GitHub App installation token and simplifies the workflow by removing ad-hoc Node scripts and npm installs.

What's changed
- Use tibdex/github-app-token@v2 to mint an installation token from APP_ID and PRIVATE_KEY secrets.
- Configure git to push using the installation token and commit directly to main (requires the App to be allowed to bypass PR requirements for main).
- Keep workflow manual-only (workflow_dispatch) with inputs for file and content.
- Minimal permissions (contents: read) since privileged ops use the App token.

How to test
- Ensure your GitHub App has Contents: Read & write and is installed on this repo.
- In Branch protection for main, add your App to "Bypass pull request requirements".
- Run the workflow from Actions -> app-commit -> Run workflow (defaults append a line to .github/healthcheck).
- Verify commit appears on main.

Security
- The tibdex action masks the token by default; no token is written to GITHUB_OUTPUT manually.

If you'd like, we can later move this job under a protected environment for extra safeguards.